### PR TITLE
Edits to revised apps/numpy_dlpack 

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,14 +2,14 @@
 
 [![Build Status](https://github.com/dmlc/dlpack/actions/workflows/main.yaml/badge.svg?branch=main)](https://github.com/dmlc/dlpack/actions/workflows/main.yaml)
 
-DLPack is an open in-memory tensor structure to for sharing tensor among frameworks. DLPack enables
+DLPack is an open in-memory tensor structure for sharing tensor among frameworks. DLPack enables
 
 - Easier sharing of operators between deep learning frameworks.
 - Easier wrapping of vendor level operator implementations, allowing collaboration when introducing new devices/ops.
 - Quick swapping of backend implementations, like different version of BLAS
 - For final users, this could bring more operators, and possibility of mixing usage between frameworks.
 
-We do not intend to implement of Tensor and Ops, but instead use this as common bridge
+We do not intend to implement Tensor and Ops, but instead use this as common bridge
 to reuse tensor and ops across frameworks.
 
 ## Proposal Procedure

--- a/apps/numpy_dlpack/dlpack/dlpack.py
+++ b/apps/numpy_dlpack/dlpack/dlpack.py
@@ -3,9 +3,38 @@ import ctypes
 _c_str_dltensor = b"dltensor"
 
 
+class DLDeviceType(ctypes.c_int):
+    kDLCPU = 1
+    kDLCUDA = 2
+    kDLCUDAHost = 3
+    kDLOpenCL = 4
+    kDLVulkan = 7
+    kDLMetal = 8
+    kDLVPI = 9
+    kDLROCM = 10
+    kDLROCMHost = 11
+    kDLCUDAManaged = 13
+    kDLOneAPI = 14
+
+    def __str__(self):
+        return {
+            self.kDLCPU : "CPU",
+            self.kDLCUDA: "CUDA",
+            self.kDLCUDAHost: "CUDAHost",
+            self.kDLOpenCL: "OpenCL",
+            self.kDLVulkan: "Vulkan",
+            self.kDLMetal: "Metal",
+            self.kDLVPI: "VPI",
+            self.kDLROCM: "ROCM",
+            self.kDLROCMHost: "ROMCHost",
+            self.kDLCUDAManaged: "CUDAManaged",
+            self.kDLOneAPI: "oneAPI",
+            }[self.value]
+
+
 class DLDevice(ctypes.Structure):
     _fields_ = [
-        ("device_type", ctypes.c_int),
+        ("device_type", DLDeviceType),
         ("device_id", ctypes.c_int),
     ]
 
@@ -15,6 +44,7 @@ class DLDataTypeCode(ctypes.c_uint8):
     kDLUInt = 1
     kDLFloat = 2
     kDLBfloat = 4
+    kDLComplex = 5
 
     def __str__(self):
         return {
@@ -22,6 +52,7 @@ class DLDataTypeCode(ctypes.c_uint8):
             self.kDLUInt: "uint",
             self.kDLFloat: "float",
             self.kDLBfloat: "bfloat",
+            self.kDLComplex: "complex"
         }[self.value]
 
 
@@ -32,13 +63,20 @@ class DLDataType(ctypes.Structure):
         ("lanes", ctypes.c_uint16),
     ]
     TYPE_MAP = {
-        "bool": (1, 1, 1),
-        "int32": (0, 32, 1),
-        "int64": (0, 64, 1),
-        "uint32": (1, 32, 1),
-        "uint64": (1, 64, 1),
-        "float32": (2, 32, 1),
-        "float64": (2, 64, 1),
+        "bool": (DLDataTypeCode.kDLUInt, 1, 1),
+        "int8": (DLDataTypeCode.kDLInt, 8, 1),
+        "int16": (DLDataTypeCode.kDLInt, 16, 1),
+        "int32": (DLDataTypeCode.kDLInt, 32, 1),
+        "int64": (DLDataTypeCode.kDLInt, 64, 1),
+        "uint8": (DLDataTypeCode.kDLUInt, 8, 1),
+        "uint16": (DLDataTypeCode.kDLUInt, 16, 1),
+        "uint32": (DLDataTypeCode.kDLUInt, 32, 1),
+        "uint64": (DLDataTypeCode.kDLUInt, 64, 1),
+        "float16": (DLDataTypeCode.kDLFloat, 16, 1),
+        "float32": (DLDataTypeCode.kDLFloat, 32, 1),
+        "float64": (DLDataTypeCode.kDLFloat, 64, 1),
+        "complex64": (DLDataTypeCode.kDLComplex, 64, 1),
+        "complex128": (DLDataTypeCode.kDLComplex, 128, 1)
     }
 
 

--- a/apps/numpy_dlpack/dlpack/dlpack.py
+++ b/apps/numpy_dlpack/dlpack/dlpack.py
@@ -4,6 +4,9 @@ _c_str_dltensor = b"dltensor"
 
 
 class DLDeviceType(ctypes.c_int):
+    """The enum that encodes the type of the device where
+    DLTensor memory is allocated.
+    """
     kDLCPU = 1
     kDLCUDA = 2
     kDLCUDAHost = 3
@@ -33,6 +36,11 @@ class DLDeviceType(ctypes.c_int):
 
 
 class DLDevice(ctypes.Structure):
+    """Represents the device where DLTensor memory is allocated.
+    The device is represented by the pair of fields:
+       device_type: DLDeviceType
+       device_id: c_int
+    """
     _fields_ = [
         ("device_type", DLDeviceType),
         ("device_id", ctypes.c_int),
@@ -40,6 +48,7 @@ class DLDevice(ctypes.Structure):
 
 
 class DLDataTypeCode(ctypes.c_uint8):
+    """An integer that encodes the category of DLTensor elements' data type."""
     kDLInt = 0
     kDLUInt = 1
     kDLFloat = 2
@@ -59,6 +68,13 @@ class DLDataTypeCode(ctypes.c_uint8):
 
 
 class DLDataType(ctypes.Structure):
+    """Descriptor of data type for elements of DLTensor.
+    The data type is described by a triple, `DLDataType.type_code`,
+    `DLDataType.bits`, and `DLDataType.lanes`.
+
+    The element is understood as packed `lanes` repetitions of
+    elements from `type_code` data-category of width `bits`.
+    """
     _fields_ = [
         ("type_code", DLDataTypeCode),
         ("bits", ctypes.c_uint8),
@@ -83,6 +99,21 @@ class DLDataType(ctypes.Structure):
 
 
 class DLTensor(ctypes.Structure):
+    """Structure describing strided layout of DLTensor.
+    Fields are:
+       data:  void pointer
+       device: DLDevice
+       ndim: number of indices needed to reference an
+             element of the tensor
+       dtype: data type descriptor
+       shape: tuple with lengths of the corresponding
+              tensor dimensions
+       strides: tuple of numbers of array elements to
+                step in each dimension when traversing
+                the tensor
+       byte_offset: data + byte_offset gives the address of
+                tensor element with index (0,) * ndim
+    """
     _fields_ = [
         ("data", ctypes.c_void_p),
         ("device", DLDevice),
@@ -95,6 +126,10 @@ class DLTensor(ctypes.Structure):
 
 
 class DLManagedTensor(ctypes.Structure):
+    """Structure storing the pointer to the tensor descriptor,
+    deleter callable for the tensor descriptor, and pointer to
+    some additional data. These are stored in fields `dl_tensor`,
+    `deleter`, and `manager_ctx`."""
     _fields_ = [
         ("dl_tensor", DLTensor),
         ("manager_ctx", ctypes.c_void_p),

--- a/apps/numpy_dlpack/dlpack/from_numpy.py
+++ b/apps/numpy_dlpack/dlpack/from_numpy.py
@@ -8,6 +8,9 @@ from .dlpack import DLManagedTensor, DLDevice, DLDataType, _c_str_dltensor
 ctypes.pythonapi.PyMem_RawMalloc.restype = ctypes.c_void_p
 ctypes.pythonapi.PyMem_RawFree.argtypes = [ctypes.c_void_p]
 
+ctypes.pythonapi.PyCapsule_New.restype=ctypes.py_object
+ctypes.pythonapi.PyCapsule_New.argtypes=[ctypes.c_void_p, ctypes.c_char_p, ctypes.c_void_p]
+
 
 class _Holder:
     """A wrapper around a numpy array to keep track of references to the underlying memory.
@@ -66,10 +69,6 @@ def from_numpy(np_array: np.ndarray):
     ----------
     np_array : np.ndarray
         The source numpy array that will be converted.
-
-    from_dlpack : Callable
-        A function that takes a dlpack pycapsule and returns an array
-        created from it.
 
     Returns
     -------

--- a/apps/numpy_dlpack/dlpack/to_numpy.py
+++ b/apps/numpy_dlpack/dlpack/to_numpy.py
@@ -8,7 +8,9 @@ ctypes.pythonapi.PyCapsule_IsValid.argtypes = [ctypes.py_object, ctypes.c_char_p
 ctypes.pythonapi.PyCapsule_GetPointer.restype = ctypes.c_void_p
 ctypes.pythonapi.PyCapsule_GetPointer.argtypes = [ctypes.py_object, ctypes.c_char_p]
 
-def array_interface_from_dl_tensor(dlt):
+def _array_interface_from_dl_tensor(dlt):
+    """Constructs NumPy's array_interface dictionary
+    from `dlpack.DLTensor` descriptor."""
     assert isinstance(dlt, DLTensor)
     shape = tuple(dlt.shape[dim] for dim in range(dlt.ndim))
     itemsize = dlt.dtype.lanes * dlt.dtype.bits // 8
@@ -73,5 +75,5 @@ def to_numpy(pycapsule) -> np.ndarray:
     )
     dl_managed_tensor_ptr = ctypes.cast(dl_managed_tensor, ctypes.POINTER(DLManagedTensor))
     dl_managed_tensor = dl_managed_tensor_ptr.contents
-    holder = _Holder(array_interface_from_dl_tensor(dl_managed_tensor.dl_tensor), pycapsule)
+    holder = _Holder(_array_interface_from_dl_tensor(dl_managed_tensor.dl_tensor), pycapsule)
     return np.ctypeslib.as_array(holder)

--- a/apps/numpy_dlpack/dlpack/to_numpy.py
+++ b/apps/numpy_dlpack/dlpack/to_numpy.py
@@ -1,6 +1,39 @@
 import ctypes
 import numpy as np
-from .dlpack import _c_str_dltensor, DLManagedTensor
+from .dlpack import _c_str_dltensor, DLManagedTensor, DLTensor
+
+ctypes.pythonapi.PyCapsule_IsValid.restype = ctypes.c_int
+ctypes.pythonapi.PyCapsule_IsValid.argtypes = [ctypes.py_object, ctypes.c_char_p]
+
+ctypes.pythonapi.PyCapsule_GetPointer.restype = ctypes.c_void_p
+ctypes.pythonapi.PyCapsule_GetPointer.argtypes = [ctypes.py_object, ctypes.c_char_p]
+
+def array_interface_from_dl_tensor(dlt):
+    assert isinstance(dlt, DLTensor)
+    shape = tuple(dlt.shape[dim] for dim in range(dlt.ndim))
+    itemsize = dlt.dtype.lanes * dlt.dtype.bits // 8
+    if dlt.strides:
+        strides = tuple(
+            dlt.strides[dim] * itemsize for dim in range(dlt.ndim)
+        )
+    else:
+        # Array is compact, make it numpy compatible.
+        strides = []
+        for i, s in enumerate(shape):
+            cumulative = 1
+            for e in range(i + 1, dlt.ndim):
+                cumulative *= shape[e]
+            strides.append(cumulative * itemsize)
+        strides = tuple(strides)
+    typestr = "|" + str(dlt.dtype.type_code)[0] + str(itemsize)
+    return dict(
+        version=3,
+        shape=shape,
+        strides=strides,
+        data=(dlt.data, True),
+        offset=dlt.byte_offset,
+        typestr=typestr,
+    )
 
 
 class _Holder:
@@ -34,11 +67,11 @@ def to_numpy(pycapsule) -> np.ndarray:
         A new numpy array that uses the same underlying memory as the input
         pycapsule.
     """
-    pycapsule = ctypes.py_object(pycapsule)
     assert ctypes.pythonapi.PyCapsule_IsValid(pycapsule, _c_str_dltensor)
     dl_managed_tensor = ctypes.pythonapi.PyCapsule_GetPointer(
         pycapsule, _c_str_dltensor
     )
-    dl_managed_tensor = ctypes.cast(dl_managed_tensor, ctypes.POINTER(DLManagedTensor))
-    holder = _Holder(dl_managed_tensor.contents.__array_interface__, pycapsule)
+    dl_managed_tensor_ptr = ctypes.cast(dl_managed_tensor, ctypes.POINTER(DLManagedTensor))
+    dl_managed_tensor = dl_managed_tensor_ptr.contents
+    holder = _Holder(array_interface_from_dl_tensor(dl_managed_tensor.dl_tensor), pycapsule)
     return np.ctypeslib.as_array(holder)

--- a/apps/numpy_dlpack/test_pure_numpy.py
+++ b/apps/numpy_dlpack/test_pure_numpy.py
@@ -1,0 +1,38 @@
+import numpy as np
+from dlpack import from_numpy, to_numpy
+
+
+def test_to_from_numpy_zero_copy():
+    """Test the copy free conversion of numpy array via DLPack."""
+    np_ary = np.random.normal(size=[10, 10])
+    np_ary_big = np.random.normal(size=[12, 10])
+    dlpack_capsule = from_numpy(np_ary_big)
+    reconstructed_ary = to_numpy(dlpack_capsule)
+    del dlpack_capsule
+    np_ary_big[1:11] = np_ary
+    del np_ary_big
+    np.testing.assert_equal(actual=reconstructed_ary[1:11], desired=np_ary)
+
+
+def test_to_from_numpy_memory():
+    """Test that DLPack capsule keeps the source array alive"""
+    source_array = np.random.normal(size=[10, 10])
+    np_array_ref = source_array.copy()
+    dlpack_capsule = from_numpy(source_array)
+    del source_array
+    reconstructed_array = to_numpy(dlpack_capsule)
+    del dlpack_capsule
+    np.testing.assert_equal(actual=reconstructed_array, desired=np_array_ref)
+
+
+if __name__ == "__main__":
+    """
+    Run both tests a bunch of times to make
+    sure the conversions and memory management are stable.
+    """
+    print("### Running `test_to_from_numpy_zero_copy`")
+    for i in range(10000):
+        test_to_from_numpy_zero_copy()
+    print("### Running `test_to_from_numpy_memory`")
+    for i in range(10000):
+        test_to_from_numpy_memory()

--- a/docs/Doxyfile.in
+++ b/docs/Doxyfile.in
@@ -1,6 +1,6 @@
 PROJECT_NAME           = @PROJECT_NAME@
 PROJECT_NUMBER         = @PROJECT_VERSION@
-PROJECT_BRIEF          = "RFC for common tensor and operator guideline in deep learning system"
+PROJECT_BRIEF          = "Common in-memory tensor structure and operator interface for deep learning and other systems"
 STRIP_FROM_PATH        = @PROJECT_SOURCE_DIR@ \
                          @PROJECT_BINARY_DIR@
 OUTPUT_LANGUAGE        = English

--- a/include/dlpack/dlpack.h
+++ b/include/dlpack/dlpack.h
@@ -143,9 +143,16 @@ typedef struct {
  */
 typedef struct {
   /*!
-   * \brief The opaque data pointer points to the allocated data. This will be
-   * CUDA device pointer or cl_mem handle in OpenCL. This pointer is always
-   * aligned to 256 bytes as in CUDA.
+   * \brief The data pointer points to the allocated data. This will be CUDA
+   * device pointer or cl_mem handle in OpenCL. It may be opaque on some device
+   * types. This pointer is always aligned to 256 bytes as in CUDA. The
+   * `byte_offset` field should be used to point to the beginning of the data.
+   *
+   * Note that as of Nov 2021, multiply libraries (CuPy, PyTorch, TensorFlow,
+   * TVM, perhaps others) do not adhere to this 256 byte aligment requirement
+   * on CPU/CUDA/ROCm, and always use `byte_offset=0`.  This must be fixed
+   * (after which this note will be updated); at the moment it is recommended
+   * to not rely on the data pointer being correctly aligned.
    *
    * For given DLTensor, the size of memory required to store the contents of
    * data is calculated as follows:

--- a/include/dlpack/dlpack.h
+++ b/include/dlpack/dlpack.h
@@ -68,6 +68,13 @@ typedef enum {
    * \brief CUDA managed/unified memory allocated by cudaMallocManaged
    */
   kDLCUDAManaged = 13,
+  /*!
+   * \brief Unified shared memory allocated on a oneAPI non-partititioned
+   * device. Call to oneAPI runtime is required to determine the device
+   * type, the USM allocation type and the sycl context it is bound to.
+   *
+   */
+  kDLOneAPI = 14,
 } DLDeviceType;
 
 /*!


### PR DESCRIPTION
This PR implements changes I suggested in the review of dmlc/dlpack#79

1. Set `.restype` and `.argtypes` for `ctypes.pythonapi.PyCapsule_*` functions to ensure that `from_numpy` returns a Python object of type `PyCapsule`.
2. Moved `__array_interface__` property from `ManagedDLTensor` and `DLTensor` classes to "to_numpy.py" as suggested by @junrushao1994 
3. Added separate test driver file which does not rely on TVM being installed. 